### PR TITLE
Solve all BIG_COMMON todo's.

### DIFF
--- a/src/Hl7.Fhir.Validation.Legacy.Shared/Schema/ValidationContext.cs
+++ b/src/Hl7.Fhir.Validation.Legacy.Shared/Schema/ValidationContext.cs
@@ -13,7 +13,5 @@ namespace Hl7.Fhir.Specification.Schema
     internal class ValidationContext
     {
         public ITerminologyService TerminologyService;
-
-        // TODO BIG_COMMON   public IExceptionSource ExceptionSink;
     }
 }

--- a/src/Hl7.Fhir.Validation.Legacy.Shared/Validation/ElementDefinitionNavigatorExtensions.cs
+++ b/src/Hl7.Fhir.Validation.Legacy.Shared/Validation/ElementDefinitionNavigatorExtensions.cs
@@ -45,13 +45,13 @@ namespace Hl7.Fhir.Validation
             var reference = sourceNavigator.Current.ContentReference;
             if (reference is null) return false;
 
-            var profileRef = TempProfileReference.Parse(reference);
+            var profileRef = new Canonical(reference);
 
-            if (profileRef.IsAbsolute && profileRef.CanonicalUrl != sourceNavigator.StructureDefinition.Url)
+            if (profileRef.IsAbsolute && profileRef.Uri != sourceNavigator.StructureDefinition.Url)
             {
                 // an external reference (e.g. http://hl7.org/fhir/StructureDefinition/Questionnaire#Questionnaire.item)
 
-                var profile = resolver(profileRef.CanonicalUrl!);
+                var profile = resolver(profileRef.Uri!);
                 if (profile is null) return false;
                 targetNavigator = ElementDefinitionNavigator.ForSnapshot(profile);
             }
@@ -61,56 +61,7 @@ namespace Hl7.Fhir.Validation
                 targetNavigator = sourceNavigator.ShallowCopy();
             }
 
-            return targetNavigator.JumpToNameReference("#" + profileRef.ElementName);
+            return targetNavigator.JumpToNameReference("#" + profileRef.Fragment);
         }
-
-
-        /// <summary>Represents a reference to an element type profile.</summary>
-        /// <remarks>Useful to parse complex profile references of the form "canonicalUrl#Type.elementName".
-        /// 
-        /// TODO BIG_COMMON: this should be refactored when we have a good solution for Canonical </remarks>
-        /// 
-        private class TempProfileReference
-        {
-            private TempProfileReference(string url)
-            {
-                if (url == null) { throw new ArgumentNullException(nameof(url)); }
-
-                var parts = url.Split('#');
-
-                if (parts.Length == 1)
-                {
-                    // Just the canonical, no '#' present
-                    CanonicalUrl = parts[0];
-                    ElementName = null;
-                }
-                else
-                {
-                    // There's a '#', so both or just the element are present
-                    CanonicalUrl = parts[0].Length > 0 ? parts[0] : null;
-                    ElementName = parts[1].Length > 0 ? parts[1] : null;
-                }
-            }
-
-            /// <summary>Initialize a new <see cref="TempProfileReference"/> instance from the specified url.</summary>
-            /// <param name="url">A resource reference to a profile.</param>
-            /// <returns>A new <see cref="TempProfileReference"/> structure.</returns>
-            public static TempProfileReference Parse(string url) => new(url);
-
-            /// <summary>Returns the canonical url of the profile.</summary>
-            public string? CanonicalUrl { get; }
-
-            /// <summary>Returns an optional profile element name, if included in the reference.</summary>
-            public string? ElementName { get; }
-
-            /// <summary>Returns <c>true</c> if the profile reference includes an element name, <c>false</c> otherwise.</summary>
-            public bool IsComplex => ElementName is not null;
-
-            /// <summary>
-            /// Returns <c>true</c> of the profile reference includes a canonical url.
-            /// </summary>
-            public bool IsAbsolute => CanonicalUrl is not null;
-        }
-
     }
 }


### PR DESCRIPTION
There were still some TODOs in the source code which were linked to the BIG_COMMON refactoring. There TODOs are solved here. 

The property of `ITerminologyService.ExceptionSink` could be removed, because it was not used and it is part of an internal class.