### PR TITLE
Devops: Use variable group APIKeys instead of separate keys

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -10,6 +10,7 @@ resources:
 
 variables:
   - group: CodeSigning
+  - group: APIKeys
   - template: variables.yml  
 
 pool: 

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -6,5 +6,5 @@ variables:
   buildConfiguration: 'Release'
   vmImage: 'windows-latest'
   DOTNET_CORE_SDK: '6.0.x'
-  GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey) # key is set in UI of Azure Devops
-  NUGET_APIKEY: $(NuGetAPIKey) # key is set in UI of Azure Devops
+  GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey) # key is set in variable group APIKeys
+  NUGET_APIKEY: $(NuGetSDKAPIKey) ## key is set in variable group APIKeys


### PR DESCRIPTION
Use the shared variable group APIKeys instead of separate keys