### PR TITLE
Upgrade to SDK 5.5.0

### DIFF
--- a/src/Hl7.Fhir.Validation.Legacy.Shared/Validation/ValidationSettings.cs
+++ b/src/Hl7.Fhir.Validation.Legacy.Shared/Validation/ValidationSettings.cs
@@ -26,7 +26,7 @@ namespace Hl7.Fhir.Validation
     {
         /// <summary>
         /// The <see cref="StructureDefinitionSummaryProvider.TypeNameMapper"/> used to map instance types encountered in
-        /// <see cref="ITypedElement.InstanceType"/> to canonicals when a profile for these types needs to be retrieved.
+        /// <see cref="IBaseElementNavigator{TDerived}.InstanceType"/> to canonicals when a profile for these types needs to be retrieved.
         /// </summary>
         public StructureDefinitionSummaryProvider.TypeNameMapper? ResourceMapping { get; set; }
 

--- a/src/firely-net-sdk-tests.props
+++ b/src/firely-net-sdk-tests.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup>
-		<FirelySdkVersion>5.5.0</FirelySdkVersion>
+		<FirelySdkVersion>5.5.1</FirelySdkVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/firely-net-sdk-tests.props
+++ b/src/firely-net-sdk-tests.props
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup>
-		<FirelySdkVersion>5.3.0</FirelySdkVersion>
+		<FirelySdkVersion>5.5.0</FirelySdkVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -6,7 +6,7 @@
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
-		<VersionPrefix>5.5.0</VersionPrefix>
+		<VersionPrefix>5.5.1</VersionPrefix>
 		<VersionSuffix>alpha</VersionSuffix>
 		<Authors>Firely (info@fire.ly) and contributors</Authors>
 		<Company>Firely (https://fire.ly)</Company>
@@ -23,7 +23,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<FirelySdkVersion>5.5.0</FirelySdkVersion>
+		<FirelySdkVersion>5.5.1</FirelySdkVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -6,7 +6,7 @@
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
-		<VersionPrefix>5.3.1</VersionPrefix>
+		<VersionPrefix>5.5.0</VersionPrefix>
 		<VersionSuffix>alpha</VersionSuffix>
 		<Authors>Firely (info@fire.ly) and contributors</Authors>
 		<Company>Firely (https://fire.ly)</Company>

--- a/src/firely-net-sdk.props
+++ b/src/firely-net-sdk.props
@@ -23,7 +23,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<FirelySdkVersion>5.3.0</FirelySdkVersion>
+		<FirelySdkVersion>5.5.0</FirelySdkVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
We have made binary incompatible changes (moving InstanceType down to IBaseElementNavigator<T>) and so this needs to be upgraded.