### PR TITLE
chore: group minor and patch dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "Moq"
       - dependency-name: "xunit"


### PR DESCRIPTION
Groups all minor and patch dependency updates into a single weekly PR, reducing noise. Major updates will still get their own individual PRs.